### PR TITLE
Add a plugin to install all components

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,6 @@
+import { plugin } from './plugin';
+
+export default plugin;
 export * from './components';
 export * from './composables';
 export { type Theme } from './types';

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,0 +1,12 @@
+import { App } from 'vue';
+import * as Components from './components';
+
+export const plugin = {
+  install: (app: App) => {
+    (Object.keys(Components) as (keyof typeof Components)[]).forEach(
+      (component) => {
+        app.component(component, Components[component]);
+      },
+    );
+  },
+};


### PR DESCRIPTION
## Description

This pull request aims to centralize all components in a plugin, so that you can install them all by just running the following code:

```ts
import { createApp } from 'vue';
import App from './App.vue';
import CelesteUI from 'celeste-ui';

createApp(App).use(CelesteUI).mount('#app');
```

## Requirements

None.

## Additional changes

None.
