### PR TITLE
Exclude @emotion/css from the final build

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,12 +15,7 @@ export default defineConfig({
       fileName: (format, entryName) => `${entryName}.${format}.js`,
     },
     rollupOptions: {
-      external: ['vue'],
-      output: {
-        globals: {
-          vue: 'Vue',
-        },
-      },
+      external: ['vue', '@emotion/css'],
     },
     sourcemap: true,
   },


### PR DESCRIPTION
## Description

Currently, the @emotion/css package was being included in the final build

This pull request aims to fix this, so that it was actually considered as an external package when building the library.

## Requirements

None.

## Additional changes

None.
