### PR TITLE
Add missing permission to storybook deploy

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
## Description

This pull request aims to fix the storybook deployment, by adding `write` permissions on the repository contents to the `GITHUB_TOKEN`.

## Requirements

None.

## Additional changes

None.
