### PR TITLE
Add tests for the `CTextField` component

### DIFF
--- a/src/components/c-text-field/c-text-field.spec.ts
+++ b/src/components/c-text-field/c-text-field.spec.ts
@@ -1,0 +1,34 @@
+import { render, screen, RenderOptions } from '@testing-library/vue';
+import { describe, it, expect } from 'vitest';
+import { CTextField } from './c-text-field';
+
+const renderComponent = (props?: RenderOptions['props']) =>
+  render(CTextField, { props });
+
+describe('CTextField', () => {
+  it('should render the component correctly', () => {
+    const container = renderComponent();
+    const inputs = container.baseElement.getElementsByTagName('input');
+    expect(inputs.length).toBe(1);
+  });
+
+  it('should display the given label', () => {
+    renderComponent({ label: 'Name', id: 'name' });
+    screen.getByLabelText('Name');
+  });
+
+  it('should display the given helper text', () => {
+    renderComponent({ helperText: 'Error' });
+    screen.getByText('Error');
+  });
+
+  it('should display the given placeholder', () => {
+    renderComponent({ placeholder: 'John Doe' });
+    screen.getAllByPlaceholderText('John Doe');
+  });
+
+  it('should disable the input', () => {
+    renderComponent({ label: 'Name', id: 'name', disabled: true });
+    screen.getByLabelText('Name');
+  });
+});

--- a/src/components/c-text-field/c-text-field.tsx
+++ b/src/components/c-text-field/c-text-field.tsx
@@ -52,6 +52,10 @@ export const CTextField = defineComponent({
     disabled: {
       type: Boolean,
     },
+    id: {
+      type: String,
+      default: null,
+    },
   },
   emits: ['update:modelValue', 'input', 'change'],
   setup(props, { emit }) {
@@ -78,7 +82,7 @@ export const CTextField = defineComponent({
     return () => (
       <celeste.div class={classes.value}>
         {props.label && (
-          <celeste.label class={`${baseClass.value}__label`}>
+          <celeste.label class={`${baseClass.value}__label`} for={props.id}>
             {props.label}
           </celeste.label>
         )}
@@ -89,6 +93,7 @@ export const CTextField = defineComponent({
           onInput={handleInput}
           placeholder={props.placeholder}
           value={props.modelValue}
+          id={props.id}
         />
         {props.helperText && (
           <celeste.span class={`${baseClass.value}__helper-text`}>

--- a/src/components/c-typography/c-typography.spec.ts
+++ b/src/components/c-typography/c-typography.spec.ts
@@ -6,60 +6,60 @@ const renderComponent = (props?: RenderOptions['props']) =>
   render(CTypography, { slots: { default: 'Hello world' }, props });
 
 describe('CTypography', () => {
-  it('Renders the given text', () => {
+  it('should render the given text', () => {
     renderComponent();
     screen.getByText('Hello world');
   });
 
-  it('Renders the correct HTML tag for and h1 variant', () => {
+  it('should render the correct HTML tag for and h1 variant', () => {
     renderComponent({ variant: 'h1' });
     const element = screen.getByText('Hello world');
     expect(element.tagName).toBe('H1');
   });
 
-  it('Renders the correct HTML tag for and h2 variant', () => {
+  it('should render the correct HTML tag for and h2 variant', () => {
     renderComponent({ variant: 'h2' });
     const element = screen.getByText('Hello world');
     expect(element.tagName).toBe('H2');
   });
 
-  it('Renders the correct HTML tag for and h3 variant', () => {
+  it('should render the correct HTML tag for and h3 variant', () => {
     renderComponent({ variant: 'h3' });
     const element = screen.getByText('Hello world');
     expect(element.tagName).toBe('H3');
   });
 
-  it('Renders the correct HTML tag for and h4 variant', () => {
+  it('should render the correct HTML tag for and h4 variant', () => {
     renderComponent({ variant: 'h4' });
     const element = screen.getByText('Hello world');
     expect(element.tagName).toBe('H4');
   });
 
-  it('Renders the correct HTML tag for and h5 variant', () => {
+  it('should render the correct HTML tag for and h5 variant', () => {
     renderComponent({ variant: 'h5' });
     const element = screen.getByText('Hello world');
     expect(element.tagName).toBe('H5');
   });
 
-  it('Renders the correct HTML tag for and h6 variant', () => {
+  it('should render the correct HTML tag for and h6 variant', () => {
     renderComponent({ variant: 'h6' });
     const element = screen.getByText('Hello world');
     expect(element.tagName).toBe('H6');
   });
 
-  it('Renders the correct HTML tag for and b1 variant', () => {
+  it('should render the correct HTML tag for and b1 variant', () => {
     renderComponent({ variant: 'b1' });
     const element = screen.getByText('Hello world');
     expect(element.tagName).toBe('P');
   });
 
-  it('Renders the correct HTML tag for and b2 variant', () => {
+  it('should render the correct HTML tag for and b2 variant', () => {
     renderComponent({ variant: 'b2' });
     const element = screen.getByText('Hello world');
     expect(element.tagName).toBe('P');
   });
 
-  it('Renders a custom tag if the "as" prop is provided', () => {
+  it('should render a custom tag if the "as" prop is provided', () => {
     renderComponent({ variant: 'h1', as: 'span' });
     const element = screen.getByText('Hello world');
     expect(element.tagName).toBe('SPAN');

--- a/src/components/c-typography/c-typography.spec.ts
+++ b/src/components/c-typography/c-typography.spec.ts
@@ -1,92 +1,66 @@
 import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/vue';
+import { RenderOptions, render, screen } from '@testing-library/vue';
 import { CTypography } from './c-typograpy';
+
+const renderComponent = (props?: RenderOptions['props']) =>
+  render(CTypography, { slots: { default: 'Hello world' }, props });
 
 describe('CTypography', () => {
   it('Renders the given text', () => {
-    render(CTypography, {
-      slots: { default: 'Hello world' },
-    });
+    renderComponent();
     screen.getByText('Hello world');
   });
 
   it('Renders the correct HTML tag for and h1 variant', () => {
-    render(CTypography, {
-      props: { variant: 'h1' },
-      slots: { default: 'Hello world' },
-    });
+    renderComponent({ variant: 'h1' });
     const element = screen.getByText('Hello world');
     expect(element.tagName).toBe('H1');
   });
 
   it('Renders the correct HTML tag for and h2 variant', () => {
-    render(CTypography, {
-      props: { variant: 'h2' },
-      slots: { default: 'Hello world' },
-    });
+    renderComponent({ variant: 'h2' });
     const element = screen.getByText('Hello world');
     expect(element.tagName).toBe('H2');
   });
 
   it('Renders the correct HTML tag for and h3 variant', () => {
-    render(CTypography, {
-      props: { variant: 'h3' },
-      slots: { default: 'Hello world' },
-    });
+    renderComponent({ variant: 'h3' });
     const element = screen.getByText('Hello world');
     expect(element.tagName).toBe('H3');
   });
 
   it('Renders the correct HTML tag for and h4 variant', () => {
-    render(CTypography, {
-      props: { variant: 'h4' },
-      slots: { default: 'Hello world' },
-    });
+    renderComponent({ variant: 'h4' });
     const element = screen.getByText('Hello world');
     expect(element.tagName).toBe('H4');
   });
 
   it('Renders the correct HTML tag for and h5 variant', () => {
-    render(CTypography, {
-      props: { variant: 'h5' },
-      slots: { default: 'Hello world' },
-    });
+    renderComponent({ variant: 'h5' });
     const element = screen.getByText('Hello world');
     expect(element.tagName).toBe('H5');
   });
 
   it('Renders the correct HTML tag for and h6 variant', () => {
-    render(CTypography, {
-      props: { variant: 'h6' },
-      slots: { default: 'Hello world' },
-    });
+    renderComponent({ variant: 'h6' });
     const element = screen.getByText('Hello world');
     expect(element.tagName).toBe('H6');
   });
 
   it('Renders the correct HTML tag for and b1 variant', () => {
-    render(CTypography, {
-      props: { variant: 'b1' },
-      slots: { default: 'Hello world' },
-    });
+    renderComponent({ variant: 'b1' });
     const element = screen.getByText('Hello world');
     expect(element.tagName).toBe('P');
   });
 
   it('Renders the correct HTML tag for and b2 variant', () => {
-    render(CTypography, {
-      props: { variant: 'b2' },
-      slots: { default: 'Hello world' },
-    });
+    renderComponent({ variant: 'b2' });
     const element = screen.getByText('Hello world');
     expect(element.tagName).toBe('P');
   });
 
   it('Renders a custom tag if the "as" prop is provided', () => {
-    render(CTypography, {
-      props: { variant: 'h1', as: 'span' },
-      slots: { default: 'Hello world' },
-    });
+    renderComponent({ variant: 'h1', as: 'span' });
     const element = screen.getByText('Hello world');
     expect(element.tagName).toBe('SPAN');
   });


### PR DESCRIPTION
## Description

This pull request aims to some basic tests cases for the `CTextField` component.

## Requirements

Run:
```bash
yarn test
```

## Additional changes

 I refactored the tests for the `CTypography` component to improve the quality and redaction of the code.
