### PR TITLE
Fix `CButton` bugs in safari

### DIFF
--- a/src/components/c-button/c-button.styles.tsx
+++ b/src/components/c-button/c-button.styles.tsx
@@ -17,7 +17,7 @@ export const useButtonStyles = () => {
     textAlign: 'center',
     textDecoration: 'none',
     lineHeight: '1.75',
-    '&:active:not(&:disabled, &[disabled])': {
+    '&:active:not(&:disabled)': {
       transform: 'translateY(2px)',
     },
     '&:focus': {
@@ -47,7 +47,7 @@ export const useButtonStyles = () => {
     '&--text': {
       backgroundColor: 'transparent',
     },
-    '&:disabled, &[disabled]': {
+    '&:disabled': {
       cursor: 'not-allowed',
     },
     ...(
@@ -67,7 +67,7 @@ export const useButtonStyles = () => {
         },
         [`&--contained&--${color}`]: {
           backgroundColor: theme.value.colors[color],
-          '&:hover:not(&:disabled, &[disabled])': {
+          '&:hover:not(&:disabled)': {
             backgroundColor: `${mix(0.05, '#000', theme.value.colors[color])}`,
             borderColor: `${mix(0.05, '#000', theme.value.colors[color])}`,
           },
@@ -75,14 +75,14 @@ export const useButtonStyles = () => {
         [`&--outlined&--${color}`]: {
           border: `1px solid ${theme.value.colors[color]}`,
           color: theme.value.colors[color],
-          '&:hover:not(&:disabled, &[disabled])': {
+          '&:hover:not(&:disabled)': {
             backgroundColor: `${mix(0.9, '#fff', theme.value.colors[color])}`,
           },
         },
         [`&--text&--${color}`]: {
           border: 'none',
           color: theme.value.colors[color],
-          '&:hover:not(&:disabled, &[disabled])': {
+          '&:hover:not(&:disabled)': {
             backgroundColor: `${mix(0.9, '#fff', theme.value.colors[color])}`,
           },
           '&:focus': {

--- a/src/components/c-button/c-button.tsx
+++ b/src/components/c-button/c-button.tsx
@@ -1,4 +1,4 @@
-import { defineComponent, computed, PropType } from 'vue';
+import { defineComponent, computed, PropType, ref } from 'vue';
 import { celeste } from '@/celeste';
 import { useButtonStyles } from './c-button.styles';
 
@@ -40,7 +40,8 @@ export const CButton = defineComponent({
       },
     ]);
 
-    const handleClick = () => {
+    const handleClick = (event: Event) => {
+      (event.currentTarget as HTMLButtonElement)?.focus();
       emit('click');
     };
 


### PR DESCRIPTION
## Description

This pull request aims to fix different bugs with the `CButton` in safari.

First of all, the button was not being focused on click, so I had to focus it programmatically. Also, the hover and active styles were not working, due to a selector not being supported.

## Requirements

None.

## Additional changes

None.
