### PR TITLE
Allow checking the `CCheckbox` by default

### DIFF
--- a/src/components/c-checkbox/c-checkbox.stories.tsx
+++ b/src/components/c-checkbox/c-checkbox.stories.tsx
@@ -18,6 +18,15 @@ export default {
         defaultValue: { summary: '"primary"' },
       },
     },
+    defaultChecked: {
+      control: { type: 'boolean' },
+      description: 'Checks the input in the initial render',
+      defaultValue: false,
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: false },
+      },
+    },
     disabled: {
       control: { type: 'boolean' },
       description: 'Sets the disabled property of the checkbox',

--- a/src/components/c-checkbox/c-checkbox.tsx
+++ b/src/components/c-checkbox/c-checkbox.tsx
@@ -30,13 +30,18 @@ export const CCheckbox = defineComponent({
     disabled: {
       type: Boolean,
     },
+    defaultChecked: {
+      type: Boolean,
+    },
   },
   emits: ['update:modelValue'],
   setup(props, { emit }) {
-    const isChecked = computed(() =>
-      Array.isArray(props.modelValue)
-        ? props.modelValue.includes(props.value)
-        : props.modelValue,
+    const isChecked = computed(
+      () =>
+        props.defaultChecked ||
+        (Array.isArray(props.modelValue)
+          ? props.modelValue.includes(props.value)
+          : props.modelValue),
     );
     const baseClass = useCheckboxStyles();
     const containerClasses = computed(() => [

--- a/src/components/c-checkbox/c-checkbox.tsx
+++ b/src/components/c-checkbox/c-checkbox.tsx
@@ -34,7 +34,7 @@ export const CCheckbox = defineComponent({
       type: Boolean,
     },
   },
-  emits: ['update:modelValue'],
+  emits: ['update:modelValue', 'input', 'change'],
   setup(props, { emit }) {
     const isChecked = computed(
       () =>
@@ -74,6 +74,8 @@ export const CCheckbox = defineComponent({
           (event.currentTarget as HTMLInputElement)?.checked,
         );
       }
+      emit('input', (event.currentTarget as HTMLInputElement)?.checked);
+      emit('change', (event.currentTarget as HTMLInputElement)?.checked);
     };
 
     return () => (


### PR DESCRIPTION
## Description

This pull request aims to add a `defaultChecked` prop to the `CCheckbox` component, so that it renders checked by default.

## Requirements

None.

## Additional changes

I also added the `change` and `input` event when checking (or unchecking) the checkbox.
