### PR TITLE
Allow passing an id to `CCheckbox`

### DIFF
--- a/src/components/c-checkbox/c-checkbox.tsx
+++ b/src/components/c-checkbox/c-checkbox.tsx
@@ -33,6 +33,10 @@ export const CCheckbox = defineComponent({
     defaultChecked: {
       type: Boolean,
     },
+    id: {
+      type: String,
+      default: undefined,
+    },
   },
   emits: ['update:modelValue', 'input', 'change'],
   setup(props, { emit }) {
@@ -86,9 +90,10 @@ export const CCheckbox = defineComponent({
           checked={isChecked.value}
           onInput={handleInput}
           disabled={props.disabled}
+          id={props.id}
         />
         {props.label && (
-          <celeste.label class={`${baseClass.value}__label`}>
+          <celeste.label class={`${baseClass.value}__label`} for={props.id}>
             {props.label}
           </celeste.label>
         )}


### PR DESCRIPTION
## Description

This pull request aims to add the `id` prop to the `CCheckbox` component, so that it can be passed as the id for the input and the displayed label (if given a label).

## Requirements

None.

## Additional changes

None.
