### PR TITLE
Use tsx in tests

### DIFF
--- a/src/components/c-button/c-button.spec.tsx
+++ b/src/components/c-button/c-button.spec.tsx
@@ -5,7 +5,7 @@ import { render, RenderOptions, screen, fireEvent } from '@testing-library/vue';
 import { CButton } from './c-button';
 
 const renderComponent = (props?: RenderOptions['props']) =>
-  render(CButton, { slots: { default: 'Click me' }, props });
+  render(<CButton {...props}>Click me</CButton>);
 
 describe('CButton', () => {
   it('should render the component correctly', () => {

--- a/src/components/c-checkbox/c-checkbox.spec.tsx
+++ b/src/components/c-checkbox/c-checkbox.spec.tsx
@@ -1,66 +1,62 @@
 import '@testing-library/jest-dom';
 
 import { describe, expect, it } from 'vitest';
-import { render, RenderOptions, screen, fireEvent } from '@testing-library/vue';
+import { render, screen, fireEvent } from '@testing-library/vue';
 import { CCheckbox } from './c-checkbox';
-
-const renderComponent = (props?: RenderOptions['props']) =>
-  render(CCheckbox, { props });
 
 describe('CCheckbox', () => {
   it('should render the component correctly', () => {
-    const container = renderComponent();
+    const container = render(<CCheckbox />);
     const input = container.baseElement.querySelector('div[role="checkbox"]');
     expect(input).toBeInTheDocument();
   });
 
   it('should display the given label', () => {
-    renderComponent({ label: 'Remember me', id: 'remember-me' });
+    render(<CCheckbox label="Remember me" id="checkbox" />);
     screen.getByLabelText('Remember me');
   });
 
   it('should disable the input', () => {
-    renderComponent({
-      label: 'Remember me',
-      id: 'remember-me',
-      disabled: true,
-    });
+    render(<CCheckbox label="Remember me" id="checkbox" disabled />);
     const input = screen.getByLabelText('Remember me');
     expect(input).toHaveAttribute('aria-disabled', 'true');
   });
 
-  it('should toggle a boolean when passing a boolean v-model', async () => {
-    const container = renderComponent({
-      modelValue: false,
-      label: 'Remember me',
-      id: 'remember-me',
-    });
+  it('should check the checkbox by default', () => {
+    render(<CCheckbox label="Remember me" id="checkbox" defaultChecked />);
+    const input = screen.getByLabelText('Remember me');
+    expect(input).toHaveAttribute('aria-checked', 'true');
+  });
+
+  it('should toggle a boolean model value', async () => {
+    const container = render(
+      <CCheckbox modelValue={false} label="Remember me" id="checkbox" />,
+    );
     const input = screen.getByLabelText('Remember me');
     await fireEvent.click(input);
     const emitted = container.emitted()['update:modelValue'] as boolean[][];
     expect(emitted[0][0]).toBe(true);
   });
 
-  it('should emit the given value in an array if passing an array as a v-model', async () => {
-    const container = renderComponent({
-      modelValue: [],
-      value: 'plane',
-      label: 'Plane',
-      id: 'transportation',
-    });
+  it('should add an item to an array model value', async () => {
+    const container = render(
+      <CCheckbox modelValue={[]} value="plane" label="Plane" id="checkbox" />,
+    );
     const input = screen.getByLabelText('Plane');
     await fireEvent.click(input);
     const emitted = container.emitted()['update:modelValue'] as string[][][];
     expect(emitted[0][0]).toEqual(['plane']);
   });
 
-  it('should remove the given value if passing an array as a v-model and it already has it', async () => {
-    const container = renderComponent({
-      modelValue: ['plane'],
-      value: 'plane',
-      label: 'Plane',
-      id: 'transportation',
-    });
+  it('should remove an item from an array model value', async () => {
+    const container = render(
+      <CCheckbox
+        modelValue={['plane']}
+        value="plane"
+        label="Plane"
+        id="checkbox"
+      />,
+    );
     const input = screen.getByLabelText('Plane');
     await fireEvent.click(input);
     const emitted = container.emitted()['update:modelValue'] as string[][][];

--- a/src/components/c-select/c-select.spec.tsx
+++ b/src/components/c-select/c-select.spec.tsx
@@ -1,31 +1,28 @@
 import '@testing-library/jest-dom';
 
-import { render, screen, RenderOptions } from '@testing-library/vue';
+import { render, screen } from '@testing-library/vue';
 import { describe, it, expect } from 'vitest';
 import { CSelect } from './c-select';
 
-const renderComponent = (props?: RenderOptions['props']) =>
-  render(CSelect, { props });
-
 describe('CSelect', () => {
   it('should render the component correctly', () => {
-    const container = renderComponent();
+    const container = render(<CSelect />);
     const selects = container.baseElement.getElementsByTagName('select');
     expect(selects.length).toBe(1);
   });
 
   it('should display the given label', () => {
-    renderComponent({ label: 'Name', id: 'name' });
+    render(<CSelect label="Name" id="name" />);
     screen.getByLabelText('Name');
   });
 
   it('should display the given helper text', () => {
-    renderComponent({ helperText: 'Error' });
+    render(<CSelect helperText="Error" />);
     screen.getByText('Error');
   });
 
   it('should display the given placeholder', () => {
-    const container = renderComponent({ placeholder: 'John Doe' });
+    const container = render(<CSelect placeholder="John Doe" />);
     const select = container.baseElement.getElementsByTagName('select')[0];
     const options = select.getElementsByTagName('option');
     expect(options.length).toBe(1);
@@ -33,7 +30,7 @@ describe('CSelect', () => {
   });
 
   it('should disable the select field', () => {
-    renderComponent({ label: 'Name', id: 'name', disabled: true });
+    render(<CSelect label="Name" id="name" disabled />);
     const select = screen.getByLabelText('Name');
     expect(select).toBeDisabled();
   });

--- a/src/components/c-select/c-select.spec.tsx
+++ b/src/components/c-select/c-select.spec.tsx
@@ -7,8 +7,8 @@ import { CSelect } from './c-select';
 describe('CSelect', () => {
   it('should render the component correctly', () => {
     const container = render(<CSelect />);
-    const selects = container.baseElement.getElementsByTagName('select');
-    expect(selects.length).toBe(1);
+    const select = container.baseElement.querySelector('select');
+    expect(select).toBeInTheDocument();
   });
 
   it('should display the given label', () => {

--- a/src/components/c-text-field/c-text-field.spec.tsx
+++ b/src/components/c-text-field/c-text-field.spec.tsx
@@ -1,36 +1,33 @@
 import '@testing-library/jest-dom';
 
-import { render, screen, RenderOptions } from '@testing-library/vue';
+import { render, screen } from '@testing-library/vue';
 import { describe, it, expect } from 'vitest';
 import { CTextField } from './c-text-field';
 
-const renderComponent = (props?: RenderOptions['props']) =>
-  render(CTextField, { props });
-
 describe('CTextField', () => {
   it('should render the component correctly', () => {
-    const container = renderComponent();
+    const container = render(<CTextField />);
     const inputs = container.baseElement.getElementsByTagName('input');
     expect(inputs.length).toBe(1);
   });
 
   it('should display the given label', () => {
-    renderComponent({ label: 'Name', id: 'name' });
+    render(<CTextField label="Name" id="name" />);
     screen.getByLabelText('Name');
   });
 
   it('should display the given helper text', () => {
-    renderComponent({ helperText: 'Error' });
+    render(<CTextField helperText="Error" />);
     screen.getByText('Error');
   });
 
   it('should display the given placeholder', () => {
-    renderComponent({ placeholder: 'John Doe' });
-    screen.getAllByPlaceholderText('John Doe');
+    render(<CTextField placeholder="John Doe" />);
+    screen.getByPlaceholderText('John Doe');
   });
 
   it('should disable the input', () => {
-    renderComponent({ label: 'Name', id: 'name', disabled: true });
+    render(<CTextField label="Name" id="name" disabled />);
     const input = screen.getByLabelText('Name');
     expect(input).toBeDisabled();
   });

--- a/src/components/c-text-field/c-text-field.spec.tsx
+++ b/src/components/c-text-field/c-text-field.spec.tsx
@@ -7,8 +7,8 @@ import { CTextField } from './c-text-field';
 describe('CTextField', () => {
   it('should render the component correctly', () => {
     const container = render(<CTextField />);
-    const inputs = container.baseElement.getElementsByTagName('input');
-    expect(inputs.length).toBe(1);
+    const input = container.baseElement.querySelector('input');
+    expect(input).toBeInTheDocument();
   });
 
   it('should display the given label', () => {

--- a/src/components/c-typography/c-typography.spec.tsx
+++ b/src/components/c-typography/c-typography.spec.tsx
@@ -1,67 +1,66 @@
 import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/vue';
+import { render, screen, RenderOptions } from '@testing-library/vue';
 import { CTypography } from './c-typograpy';
+
+const renderComponent = (props?: RenderOptions['props']) =>
+  render(<CTypography {...props}>Hello world</CTypography>);
 
 describe('CTypography', () => {
   it('should render the given text', () => {
-    render(<CTypography>Hello world</CTypography>);
+    renderComponent();
     screen.getByText('Hello world');
   });
 
   it('should render the correct HTML tag for and h1 variant', () => {
-    render(<CTypography variant="h1">Hello world</CTypography>);
+    renderComponent({ variant: 'h1' });
     const element = screen.getByText('Hello world');
     expect(element.tagName).toBe('H1');
   });
 
   it('should render the correct HTML tag for and h2 variant', () => {
-    render(<CTypography variant="h2">Hello world</CTypography>);
+    renderComponent({ variant: 'h2' });
     const element = screen.getByText('Hello world');
     expect(element.tagName).toBe('H2');
   });
 
   it('should render the correct HTML tag for and h3 variant', () => {
-    render(<CTypography variant="h3">Hello world</CTypography>);
+    renderComponent({ variant: 'h3' });
     const element = screen.getByText('Hello world');
     expect(element.tagName).toBe('H3');
   });
 
   it('should render the correct HTML tag for and h4 variant', () => {
-    render(<CTypography variant="h4">Hello world</CTypography>);
+    renderComponent({ variant: 'h4' });
     const element = screen.getByText('Hello world');
     expect(element.tagName).toBe('H4');
   });
 
   it('should render the correct HTML tag for and h5 variant', () => {
-    render(<CTypography variant="h5">Hello world</CTypography>);
+    renderComponent({ variant: 'h5' });
     const element = screen.getByText('Hello world');
     expect(element.tagName).toBe('H5');
   });
 
   it('should render the correct HTML tag for and h6 variant', () => {
-    render(<CTypography variant="h6">Hello world</CTypography>);
+    renderComponent({ variant: 'h6' });
     const element = screen.getByText('Hello world');
     expect(element.tagName).toBe('H6');
   });
 
   it('should render the correct HTML tag for and b1 variant', () => {
-    render(<CTypography variant="b1">Hello world</CTypography>);
+    renderComponent({ variant: 'b1' });
     const element = screen.getByText('Hello world');
     expect(element.tagName).toBe('P');
   });
 
   it('should render the correct HTML tag for and b2 variant', () => {
-    render(<CTypography variant="b2">Hello world</CTypography>);
+    renderComponent({ variant: 'b2' });
     const element = screen.getByText('Hello world');
     expect(element.tagName).toBe('P');
   });
 
   it('should render a custom tag if the "as" prop is provided', () => {
-    render(
-      <CTypography variant="h1" as="span">
-        Hello world
-      </CTypography>,
-    );
+    renderComponent({ variant: 'h1', as: 'span' });
     const element = screen.getByText('Hello world');
     expect(element.tagName).toBe('SPAN');
   });

--- a/src/components/c-typography/c-typography.spec.tsx
+++ b/src/components/c-typography/c-typography.spec.tsx
@@ -1,66 +1,67 @@
 import { describe, it, expect } from 'vitest';
-import { RenderOptions, render, screen } from '@testing-library/vue';
+import { render, screen } from '@testing-library/vue';
 import { CTypography } from './c-typograpy';
-
-const renderComponent = (props?: RenderOptions['props']) =>
-  render(CTypography, { slots: { default: 'Hello world' }, props });
 
 describe('CTypography', () => {
   it('should render the given text', () => {
-    renderComponent();
+    render(<CTypography>Hello world</CTypography>);
     screen.getByText('Hello world');
   });
 
   it('should render the correct HTML tag for and h1 variant', () => {
-    renderComponent({ variant: 'h1' });
+    render(<CTypography variant="h1">Hello world</CTypography>);
     const element = screen.getByText('Hello world');
     expect(element.tagName).toBe('H1');
   });
 
   it('should render the correct HTML tag for and h2 variant', () => {
-    renderComponent({ variant: 'h2' });
+    render(<CTypography variant="h2">Hello world</CTypography>);
     const element = screen.getByText('Hello world');
     expect(element.tagName).toBe('H2');
   });
 
   it('should render the correct HTML tag for and h3 variant', () => {
-    renderComponent({ variant: 'h3' });
+    render(<CTypography variant="h3">Hello world</CTypography>);
     const element = screen.getByText('Hello world');
     expect(element.tagName).toBe('H3');
   });
 
   it('should render the correct HTML tag for and h4 variant', () => {
-    renderComponent({ variant: 'h4' });
+    render(<CTypography variant="h4">Hello world</CTypography>);
     const element = screen.getByText('Hello world');
     expect(element.tagName).toBe('H4');
   });
 
   it('should render the correct HTML tag for and h5 variant', () => {
-    renderComponent({ variant: 'h5' });
+    render(<CTypography variant="h5">Hello world</CTypography>);
     const element = screen.getByText('Hello world');
     expect(element.tagName).toBe('H5');
   });
 
   it('should render the correct HTML tag for and h6 variant', () => {
-    renderComponent({ variant: 'h6' });
+    render(<CTypography variant="h6">Hello world</CTypography>);
     const element = screen.getByText('Hello world');
     expect(element.tagName).toBe('H6');
   });
 
   it('should render the correct HTML tag for and b1 variant', () => {
-    renderComponent({ variant: 'b1' });
+    render(<CTypography variant="b1">Hello world</CTypography>);
     const element = screen.getByText('Hello world');
     expect(element.tagName).toBe('P');
   });
 
   it('should render the correct HTML tag for and b2 variant', () => {
-    renderComponent({ variant: 'b2' });
+    render(<CTypography variant="b2">Hello world</CTypography>);
     const element = screen.getByText('Hello world');
     expect(element.tagName).toBe('P');
   });
 
   it('should render a custom tag if the "as" prop is provided', () => {
-    renderComponent({ variant: 'h1', as: 'span' });
+    render(
+      <CTypography variant="h1" as="span">
+        Hello world
+      </CTypography>,
+    );
     const element = screen.getByText('Hello world');
     expect(element.tagName).toBe('SPAN');
   });


### PR DESCRIPTION
## Description

This pull request aims to refactor every tests, so that it uses tsx to render the tested component, instead of calling the `render` function and passing options as an object.

To check that they all run correctly, run:

```bash
yarn test
```

## Requirements

None.

## Additional changes

None.
