### PR TITLE
Export `CButton` props type

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -27,7 +27,8 @@
     "import/no-extraneous-dependencies": "off",
     "import/prefer-default-export": "off",
     "react/jsx-props-no-spreading": "off",
-    "@typescript-eslint/restrict-template-expressions": "off"
+    "@typescript-eslint/restrict-template-expressions": "off",
+    "vue/require-default-prop": "off"
   },
   "settings": {
     "import/resolver": {

--- a/src/celeste.ts
+++ b/src/celeste.ts
@@ -1,3 +1,12 @@
-import { polymorphicFactory } from '@polymorphic-factory/vue';
+import {
+  polymorphicFactory,
+  type DOMElements,
+  type HTMLPolymorphicComponents,
+  type HTMLPolymorphicProps,
+} from '@polymorphic-factory/vue';
+
+export type HTMLCelesteComponents = HTMLPolymorphicComponents;
+
+export type HTMLCelesteProps<T extends DOMElements> = HTMLPolymorphicProps<T>;
 
 export const celeste = polymorphicFactory();

--- a/src/components/c-button/c-button.tsx
+++ b/src/components/c-button/c-button.tsx
@@ -1,4 +1,4 @@
-import { defineComponent, computed } from 'vue';
+import { defineComponent, computed, PropType } from 'vue';
 import merge from 'lodash/merge';
 import { celeste, HTMLCelesteProps } from '@/celeste';
 import { type Assign } from '@/types';
@@ -21,8 +21,15 @@ const defaultProps = {
   variant: 'contained',
 };
 
-export const CButton = defineComponent<CButtonProps>({
+export const CButton = defineComponent({
   name: 'CButton',
+  props: {
+    size: String as PropType<CButtonProps['size']>,
+    color: String as PropType<CButtonProps['color']>,
+    fullWidth: Boolean as PropType<CButtonProps['fullWidth']>,
+    variant: String as PropType<CButtonProps['variant']>,
+    disabled: Boolean as PropType<CButtonProps['disabled']>,
+  },
   emits: ['click'],
   setup(_props, { slots, emit, attrs }) {
     const props = computed(() => merge({}, defaultProps, _props, attrs));

--- a/src/components/c-button/c-button.tsx
+++ b/src/components/c-button/c-button.tsx
@@ -1,4 +1,4 @@
-import { defineComponent, computed, PropType } from 'vue';
+import { defineComponent, computed } from 'vue';
 import merge from 'lodash/merge';
 import { celeste, HTMLCelesteProps } from '@/celeste';
 import { type Assign } from '@/types';
@@ -21,15 +21,8 @@ const defaultProps = {
   variant: 'contained',
 };
 
-export const CButton = defineComponent({
+export const CButton = defineComponent<CButtonProps>({
   name: 'CButton',
-  props: {
-    size: String as PropType<CButtonProps['size']>,
-    color: String as PropType<CButtonProps['color']>,
-    fullWidth: Boolean as PropType<CButtonProps['fullWidth']>,
-    variant: String as PropType<CButtonProps['variant']>,
-    disabled: Boolean as PropType<CButtonProps['disabled']>,
-  },
   emits: ['click'],
   setup(_props, { slots, emit, attrs }) {
     const props = computed(() => merge({}, defaultProps, _props, attrs));

--- a/src/components/c-button/c-button.tsx
+++ b/src/components/c-button/c-button.tsx
@@ -1,42 +1,47 @@
 import { defineComponent, computed, PropType } from 'vue';
-import { celeste } from '@/celeste';
+import merge from 'lodash/merge';
+import { celeste, HTMLCelesteProps } from '@/celeste';
+import { type Assign } from '@/types';
 import { useButtonStyles } from './c-button.styles';
+
+export type CButtonProps = Assign<
+  HTMLCelesteProps<'button'>,
+  {
+    color?: 'primary' | 'success' | 'info' | 'warning' | 'danger';
+    disabled?: boolean;
+    fullWidth?: boolean;
+    size?: 'small' | 'medium' | 'large';
+    variant?: 'contained' | 'outlined' | 'text';
+  }
+>;
+
+const defaultProps = {
+  color: 'primary',
+  size: 'medium',
+  variant: 'contained',
+};
 
 export const CButton = defineComponent({
   name: 'CButton',
   props: {
-    size: {
-      type: String as PropType<'small' | 'medium' | 'large'>,
-      default: 'medium',
-    },
-    color: {
-      type: String as PropType<
-        'primary' | 'success' | 'info' | 'warning' | 'danger'
-      >,
-      default: 'primary',
-    },
-    fullWidth: {
-      type: Boolean,
-    },
-    variant: {
-      type: String as PropType<'contained' | 'outlined' | 'text'>,
-      default: 'contained',
-    },
-    disabled: {
-      type: Boolean,
-    },
+    size: String as PropType<CButtonProps['size']>,
+    color: String as PropType<CButtonProps['color']>,
+    fullWidth: Boolean as PropType<CButtonProps['fullWidth']>,
+    variant: String as PropType<CButtonProps['variant']>,
+    disabled: Boolean as PropType<CButtonProps['disabled']>,
   },
   emits: ['click'],
-  setup(props, { slots, emit }) {
+  setup(_props, { slots, emit, attrs }) {
+    const props = computed(() => merge({}, defaultProps, _props, attrs));
     const baseClass = useButtonStyles();
 
     const classes = computed(() => [
       baseClass.value,
-      `${baseClass.value}--${props.size}`,
-      `${baseClass.value}--${props.variant}`,
-      `${baseClass.value}--${props.color}`,
+      `${baseClass.value}--${props.value.size}`,
+      `${baseClass.value}--${props.value.variant}`,
+      `${baseClass.value}--${props.value.color}`,
       {
-        [`${baseClass.value}--full-width`]: props.fullWidth,
+        [`${baseClass.value}--full-width`]: props.value.fullWidth,
       },
     ]);
 
@@ -47,10 +52,11 @@ export const CButton = defineComponent({
 
     return () => (
       <celeste.button
-        disabled={props.disabled}
+        disabled={props.value.disabled}
         class={classes.value}
         type="button"
         onClick={handleClick}
+        {...attrs}
       >
         {slots.default?.()}
       </celeste.button>

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -1,3 +1,5 @@
 export type DeepPartial<T> = {
   [P in keyof T]?: T[P] extends object ? DeepPartial<T[P]> : T[P];
 };
+
+export type Assign<Target, Source> = Omit<Target, keyof Source> & Source;


### PR DESCRIPTION
## Description

This pull request aims to generate and export the `CButton` prop type, so that it can be reused by the user.

## Requirements

None.

## Additional changes

None.
