### PR TITLE
Export `CTypography` props type

### DIFF
--- a/src/components/c-typography/c-typograpy.tsx
+++ b/src/components/c-typography/c-typograpy.tsx
@@ -1,36 +1,38 @@
 import { PropType, computed, defineComponent } from 'vue';
+import merge from 'lodash/merge';
 import { ElementType } from '@polymorphic-factory/vue';
-import { celeste } from '@/celeste';
+import { HTMLCelesteProps, celeste } from '@/celeste';
+import { Assign } from '@/types';
 import { useTypographyStyles } from './c-typography.styles';
+
+export type CTypographyProps = Assign<
+  HTMLCelesteProps<'p'>,
+  {
+    align?: 'center' | 'inherit' | 'justify' | 'left' | 'right';
+    as?: ElementType;
+    fontWeight?: 'thin' | 'light' | 'regular' | 'bold' | 'black';
+    noWrap?: boolean;
+    variant?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'b1' | 'b2';
+  }
+>;
+
+const defaultProps = {
+  variant: 'b1',
+  fontWeight: 'regular',
+  align: 'inherit',
+};
 
 export const CTypography = defineComponent({
   name: 'CTypography',
   props: {
-    variant: {
-      type: String as PropType<
-        'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'b1' | 'b2'
-      >,
-      default: 'b1',
-    },
-    as: {
-      type: String as PropType<ElementType>,
-      default: null,
-    },
-    fontWeight: {
-      type: String as PropType<'thin' | 'light' | 'regular' | 'bold' | 'black'>,
-      default: 'regular',
-    },
-    align: {
-      type: String as PropType<
-        'center' | 'inherit' | 'justify' | 'left' | 'right'
-      >,
-      default: 'inherit',
-    },
-    noWrap: {
-      type: Boolean,
-    },
+    variant: String as PropType<CTypographyProps['variant']>,
+    as: String as PropType<CTypographyProps['as']>,
+    fontWeight: String as PropType<CTypographyProps['fontWeight']>,
+    align: String as PropType<CTypographyProps['align']>,
+    noWrap: Boolean as PropType<CTypographyProps['noWrap']>,
   },
-  setup(props, { slots }) {
+  setup(_props, { slots, attrs }) {
+    const props = computed(() => merge({}, defaultProps, _props, attrs));
     const defaultMapping = {
       h1: 'h1',
       h2: 'h2',
@@ -42,17 +44,19 @@ export const CTypography = defineComponent({
       b2: 'p',
     };
 
-    const tag = computed(() => props.as || defaultMapping[props.variant]);
+    const tag = computed(
+      () =>
+        props.value.as || (defaultMapping[props.value.variant] as ElementType),
+    );
 
     const baseClass = useTypographyStyles();
-
     const classes = computed(() => [
       baseClass.value,
-      `${baseClass.value}--${props.variant}`,
-      `${baseClass.value}--${props.fontWeight}`,
-      `${baseClass.value}--${props.align}`,
+      `${baseClass.value}--${props.value.variant}`,
+      `${baseClass.value}--${props.value.fontWeight}`,
+      `${baseClass.value}--${props.value.align}`,
       {
-        [`${baseClass.value}--no-wrap`]: props.noWrap,
+        [`${baseClass.value}--no-wrap`]: props.value.noWrap,
       },
     ]);
     return () => (


### PR DESCRIPTION
## Description

This pull request aims to generate and export the `CTypography` prop type, so that it can be reused by the user.

## Requirements

None.

## Additional changes

None.
